### PR TITLE
Made android_home parameter optional

### DIFF
--- a/lib/fastlane/plugin/msbuild/actions/msbuild_action.rb
+++ b/lib/fastlane/plugin/msbuild/actions/msbuild_action.rb
@@ -80,6 +80,7 @@ module Fastlane
 
           FastlaneCore::ConfigItem.new(
             key: :android_home,
+            optional: true,
             env_name: 'ANDROID_HOME',
             description: 'Location of the Anrdoid SDK (defaults to $ANDROID_HOME)',
             type: String


### PR DESCRIPTION
For most installations the default of not specifying the parameter works fine.